### PR TITLE
Ajuste de buenas practicas

### DIFF
--- a/ApiSpaceShooter.Application/DTOs/ScoreStatistics.cs
+++ b/ApiSpaceShooter.Application/DTOs/ScoreStatistics.cs
@@ -1,0 +1,11 @@
+namespace ApiSpaceShooter.Application.DTOs;
+
+public record ScoreStatistics(
+    string Alias,
+    int TotalGames,
+    int BestScore,
+    double AverageScore,
+    int BestCombo,
+    int ShortestDuration,
+    DateTime FirstGameDate,
+    DateTime LastGameDate);

--- a/ApiSpaceShooter.Application/Ports/IBaseRepository.cs
+++ b/ApiSpaceShooter.Application/Ports/IBaseRepository.cs
@@ -1,0 +1,17 @@
+namespace ApiSpaceShooter.Application.Ports;
+
+using System.Linq.Expressions;
+
+public interface IBaseRepository<TEntity> where TEntity : class
+{
+    Task<TEntity?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<TEntity>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<TEntity>> FindAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
+    Task<TEntity?> SingleOrDefaultAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
+    Task<int> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
+    Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+    void Update(TEntity entity);
+    void Delete(TEntity entity);
+    Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
+    Task<int> CountAsync(Expression<Func<TEntity, bool>>? predicate = null, CancellationToken cancellationToken = default);
+}

--- a/ApiSpaceShooter.Application/Ports/IScoreRepository.cs
+++ b/ApiSpaceShooter.Application/Ports/IScoreRepository.cs
@@ -1,10 +1,21 @@
 namespace ApiSpaceShooter.Application.Ports;
 
 using ApiSpaceShooter.Domain.Entities;
+using ApiSpaceShooter.Application.DTOs;
 
-public interface IScoreRepository
+public interface IScoreRepository : IBaseRepository<Score>
 {
+    // Métodos existentes mejorados
     Task<int> CreateAsync(Score score, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Score>> GetTopAsync(int limit, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Score>> GetByAliasAsync(string alias, CancellationToken cancellationToken = default);
+    
+    // Nuevos métodos para mejor funcionalidad
+    Task<IReadOnlyList<Score>> GetTopByDateRangeAsync(int limit, DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default);
+    Task<Score?> GetBestScoreByAliasAsync(string alias, CancellationToken cancellationToken = default);
+    Task<ScoreStatistics> GetStatisticsByAliasAsync(string alias, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Score>> GetRecentScoresAsync(int limit = 10, CancellationToken cancellationToken = default);
+    Task<bool> HasScoresForAliasAsync(string alias, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> GetTopPlayersAsync(int limit, CancellationToken cancellationToken = default);
+    Task<int> GetRankingPositionAsync(int scoreId, CancellationToken cancellationToken = default);
 }

--- a/ApiSpaceShooter.Application/Ports/IUnitOfWork.cs
+++ b/ApiSpaceShooter.Application/Ports/IUnitOfWork.cs
@@ -1,0 +1,10 @@
+namespace ApiSpaceShooter.Application.Ports;
+
+public interface IUnitOfWork : IDisposable
+{
+    IScoreRepository Scores { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+    Task BeginTransactionAsync(CancellationToken cancellationToken = default);
+    Task CommitTransactionAsync(CancellationToken cancellationToken = default);
+    Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
+}

--- a/ApiSpaceShooter.Infrastructure/Persistence/BaseRepository.cs
+++ b/ApiSpaceShooter.Infrastructure/Persistence/BaseRepository.cs
@@ -1,0 +1,164 @@
+namespace ApiSpaceShooter.Infrastructure.Persistence;
+
+using ApiSpaceShooter.Application.Ports;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq.Expressions;
+
+public abstract class BaseRepository<TEntity> : IBaseRepository<TEntity> where TEntity : class
+{
+    protected readonly AppDbContext Context;
+    protected readonly DbSet<TEntity> DbSet;
+    protected readonly ILogger Logger;
+
+    protected BaseRepository(AppDbContext context, ILogger logger)
+    {
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+        DbSet = context.Set<TEntity>();
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public virtual async Task<TEntity?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await DbSet.FindAsync([id], cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error retrieving entity {EntityType} with id {Id}", typeof(TEntity).Name, id);
+            throw;
+        }
+    }
+
+    public virtual async Task<IReadOnlyList<TEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await DbSet.AsNoTracking().ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error retrieving all entities of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual async Task<IReadOnlyList<TEntity>> FindAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await DbSet.AsNoTracking().Where(predicate).ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error finding entities of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual async Task<TEntity?> SingleOrDefaultAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await DbSet.AsNoTracking().SingleOrDefaultAsync(predicate, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error retrieving single entity of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual async Task<int> AddAsync(TEntity entity, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(entity);
+            
+            var entry = await DbSet.AddAsync(entity, cancellationToken);
+            await Context.SaveChangesAsync(cancellationToken);
+            
+            // Asumiendo que la entidad tiene una propiedad Id
+            var idProperty = typeof(TEntity).GetProperty("Id");
+            return idProperty?.GetValue(entity) as int? ?? 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error adding entity of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual async Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(entities);
+            
+            await DbSet.AddRangeAsync(entities, cancellationToken);
+            await Context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error adding range of entities of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual void Update(TEntity entity)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(entity);
+            DbSet.Update(entity);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error updating entity of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual void Delete(TEntity entity)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(entity);
+            DbSet.Remove(entity);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error deleting entity of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual async Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await DbSet.AnyAsync(predicate, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error checking existence of entity of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+
+    public virtual async Task<int> CountAsync(Expression<Func<TEntity, bool>>? predicate = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return predicate == null 
+                ? await DbSet.CountAsync(cancellationToken)
+                : await DbSet.CountAsync(predicate, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error counting entities of type {EntityType}", typeof(TEntity).Name);
+            throw;
+        }
+    }
+}

--- a/ApiSpaceShooter.Infrastructure/Persistence/ScoreRepository.cs
+++ b/ApiSpaceShooter.Infrastructure/Persistence/ScoreRepository.cs
@@ -2,41 +2,236 @@ namespace ApiSpaceShooter.Infrastructure.Persistence;
 
 using ApiSpaceShooter.Domain.Entities;
 using ApiSpaceShooter.Application.Ports;
+using ApiSpaceShooter.Application.DTOs;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
-public class ScoreRepository : IScoreRepository
+public class ScoreRepository : BaseRepository<Score>, IScoreRepository
 {
-    private readonly AppDbContext _context;
-
-    public ScoreRepository(AppDbContext context)
+    public ScoreRepository(AppDbContext context, ILogger<ScoreRepository> logger) 
+        : base(context, logger)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
     public async Task<int> CreateAsync(Score score, CancellationToken cancellationToken = default)
     {
-        _context.Scores.Add(score);
-        await _context.SaveChangesAsync(cancellationToken);
-        return score.Id;
+        try
+        {
+            ArgumentNullException.ThrowIfNull(score);
+            Logger.LogInformation("Creating new score for alias {Alias} with {Points} points", score.Alias, score.Points);
+
+            return await AddAsync(score, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to create score for alias {Alias}", score?.Alias);
+            throw;
+        }
     }
 
     public async Task<IReadOnlyList<Score>> GetTopAsync(int limit, CancellationToken cancellationToken = default)
     {
-        return await _context.Scores
-            .AsNoTracking()
-            .OrderByDescending(s => s.Points)
-            .ThenBy(s => s.DurationSec)
-            .ThenBy(s => s.CreatedAt)
-            .Take(limit)
-            .ToListAsync(cancellationToken);
+        try
+        {
+            Logger.LogInformation("Retrieving top {Limit} scores", limit);
+
+            return await Context.Scores
+                .AsNoTracking()
+                .OrderByDescending(s => s.Points)
+                .ThenBy(s => s.DurationSec)
+                .ThenBy(s => s.CreatedAt)
+                .Take(limit)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to retrieve top {Limit} scores", limit);
+            throw;
+        }
     }
 
     public async Task<IReadOnlyList<Score>> GetByAliasAsync(string alias, CancellationToken cancellationToken = default)
     {
-        return await _context.Scores
-            .AsNoTracking()
-            .Where(s => s.Alias == alias)
-            .OrderByDescending(s => s.CreatedAt)
-            .ToListAsync(cancellationToken);
+        try
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+            Logger.LogInformation("Retrieving scores for alias {Alias}", alias);
+
+            return await Context.Scores
+                .AsNoTracking()
+                .Where(s => s.Alias == alias)
+                .OrderByDescending(s => s.CreatedAt)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to retrieve scores for alias {Alias}", alias);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<Score>> GetTopByDateRangeAsync(int limit, DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            Logger.LogInformation("Retrieving top {Limit} scores between {FromDate} and {ToDate}", limit, fromDate, toDate);
+
+            return await Context.Scores
+                .AsNoTracking()
+                .Where(s => s.CreatedAt >= fromDate && s.CreatedAt <= toDate)
+                .OrderByDescending(s => s.Points)
+                .ThenBy(s => s.DurationSec)
+                .ThenBy(s => s.CreatedAt)
+                .Take(limit)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to retrieve top scores for date range {FromDate} to {ToDate}", fromDate, toDate);
+            throw;
+        }
+    }
+
+    public async Task<Score?> GetBestScoreByAliasAsync(string alias, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+            Logger.LogInformation("Retrieving best score for alias {Alias}", alias);
+
+            return await Context.Scores
+                .AsNoTracking()
+                .Where(s => s.Alias == alias)
+                .OrderByDescending(s => s.Points)
+                .ThenBy(s => s.DurationSec)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to retrieve best score for alias {Alias}", alias);
+            throw;
+        }
+    }
+
+    public async Task<ScoreStatistics> GetStatisticsByAliasAsync(string alias, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+            Logger.LogInformation("Computing statistics for alias {Alias}", alias);
+
+            var scores = await Context.Scores
+                .AsNoTracking()
+                .Where(s => s.Alias == alias)
+                .ToListAsync(cancellationToken);
+
+            if (!scores.Any())
+            {
+                throw new InvalidOperationException($"No scores found for alias '{alias}'");
+            }
+
+            return new ScoreStatistics(
+                Alias: alias,
+                TotalGames: scores.Count,
+                BestScore: scores.Max(s => s.Points),
+                AverageScore: scores.Average(s => s.Points),
+                BestCombo: scores.Where(s => s.MaxCombo.HasValue).DefaultIfEmpty().Max(s => s?.MaxCombo) ?? 0,
+                ShortestDuration: scores.Where(s => s.DurationSec.HasValue).DefaultIfEmpty().Min(s => s?.DurationSec) ?? 0,
+                FirstGameDate: scores.Min(s => s.CreatedAt),
+                LastGameDate: scores.Max(s => s.CreatedAt)
+            );
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to compute statistics for alias {Alias}", alias);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<Score>> GetRecentScoresAsync(int limit = 10, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            Logger.LogInformation("Retrieving {Limit} most recent scores", limit);
+
+            return await Context.Scores
+                .AsNoTracking()
+                .OrderByDescending(s => s.CreatedAt)
+                .Take(limit)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to retrieve recent scores");
+            throw;
+        }
+    }
+
+    public async Task<bool> HasScoresForAliasAsync(string alias, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+            
+            return await ExistsAsync(s => s.Alias == alias, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to check if alias {Alias} has scores", alias);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetTopPlayersAsync(int limit, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            Logger.LogInformation("Retrieving top {Limit} players by best score", limit);
+
+            return await Context.Scores
+                .AsNoTracking()
+                .GroupBy(s => s.Alias)
+                .Select(g => new { Alias = g.Key, BestScore = g.Max(s => s.Points) })
+                .OrderByDescending(x => x.BestScore)
+                .Take(limit)
+                .Select(x => x.Alias)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to retrieve top players");
+            throw;
+        }
+    }
+
+    public async Task<int> GetRankingPositionAsync(int scoreId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            Logger.LogInformation("Computing ranking position for score {ScoreId}", scoreId);
+
+            var score = await Context.Scores
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.Id == scoreId, cancellationToken);
+
+            if (score == null)
+            {
+                throw new InvalidOperationException($"Score with ID {scoreId} not found");
+            }
+
+            var position = await Context.Scores
+                .AsNoTracking()
+                .Where(s => s.Points > score.Points || 
+                           (s.Points == score.Points && s.DurationSec < score.DurationSec) ||
+                           (s.Points == score.Points && s.DurationSec == score.DurationSec && s.CreatedAt < score.CreatedAt))
+                .CountAsync(cancellationToken);
+
+            return position + 1; // Position is 1-based
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to compute ranking position for score {ScoreId}", scoreId);
+            throw;
+        }
     }
 }

--- a/ApiSpaceShooter.Infrastructure/Persistence/UnitOfWork.cs
+++ b/ApiSpaceShooter.Infrastructure/Persistence/UnitOfWork.cs
@@ -1,0 +1,102 @@
+namespace ApiSpaceShooter.Infrastructure.Persistence;
+
+using ApiSpaceShooter.Application.Ports;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly AppDbContext _context;
+    private readonly ILogger<UnitOfWork> _logger;
+    private IDbContextTransaction? _transaction;
+    private readonly IScoreRepository _scoreRepository;
+
+    public UnitOfWork(AppDbContext context, ILogger<UnitOfWork> logger, IScoreRepository scoreRepository)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _scoreRepository = scoreRepository ?? throw new ArgumentNullException(nameof(scoreRepository));
+    }
+
+    public IScoreRepository Scores => _scoreRepository;
+
+    public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var changes = await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("Saved {Changes} changes to database", changes);
+            return changes;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save changes to database");
+            throw;
+        }
+    }
+
+    public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+            _logger.LogInformation("Database transaction started");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start database transaction");
+            throw;
+        }
+    }
+
+    public async Task CommitTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (_transaction == null)
+                throw new InvalidOperationException("No active transaction to commit");
+
+            await _transaction.CommitAsync(cancellationToken);
+            _logger.LogInformation("Database transaction committed");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to commit database transaction");
+            await RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
+        finally
+        {
+            _transaction?.Dispose();
+            _transaction = null;
+        }
+    }
+
+    public async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (_transaction != null)
+            {
+                await _transaction.RollbackAsync(cancellationToken);
+                _logger.LogInformation("Database transaction rolled back");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rollback database transaction");
+            throw;
+        }
+        finally
+        {
+            _transaction?.Dispose();
+            _transaction = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        _transaction?.Dispose();
+        _context?.Dispose();
+    }
+}

--- a/ApiSpaceShooter/Configuration/ServiceCollectionExtensions.cs
+++ b/ApiSpaceShooter/Configuration/ServiceCollectionExtensions.cs
@@ -14,14 +14,24 @@ public static class ServiceCollectionExtensions
             ?? "Server=localhost,1433;Database=SpaceShooter;User Id=sa;Password=Your_password123;TrustServerCertificate=True";
 
         services.AddDbContext<AppDbContext>(options =>
-            options.UseSqlServer(connectionString));
+        {
+            options.UseSqlServer(connectionString);
+            options.EnableSensitiveDataLogging(false);
+            options.EnableDetailedErrors(false);
+        });
 
         return services;
     }
 
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
+        // Repository Pattern
         services.AddScoped<IScoreRepository, ScoreRepository>();
+        
+        // Unit of Work Pattern
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+        
+        // Use Cases
         services.AddScoped<CreateScore>();
         services.AddScoped<GetTopScores>();
         services.AddScoped<GetScoresByAlias>();
@@ -52,7 +62,7 @@ public static class ServiceCollectionExtensions
             c.SwaggerDoc("v1", new() { 
                 Title = "Space Shooter API", 
                 Version = "v1",
-                Description = "API para gestión de puntajes del juego Space Shooter"
+                Description = "API para gestión de puntajes del juego Space Shooter con arquitectura hexagonal"
             });
         });
 


### PR DESCRIPTION
This pull request introduces a repository and unit of work pattern to the application, significantly refactoring the data access layer for scores. It adds generic and score-specific repository interfaces and implementations, a unit of work abstraction, and enhances dependency injection configuration. Additionally, it introduces new score statistics functionality and improves error handling and logging throughout the persistence layer.

**Repository and Unit of Work Pattern Implementation:**

- Introduced a generic repository interface `IBaseRepository<TEntity>` and its implementation `BaseRepository<TEntity>`, providing common data access methods with error handling and logging. [[1]](diffhunk://#diff-2f4a93cf898f6a00b33317fdfb3f473f99011337ceee8741343aa8584b4d9b50R1-R17) [[2]](diffhunk://#diff-5422b03ce31af691199c09874c2ecab76012725daa60d9a17143165fd8e11775R1-R164)
- Added a `UnitOfWork` pattern via the `IUnitOfWork` interface and its implementation, which manages transactions and coordinates repositories. [[1]](diffhunk://#diff-02d5b38bfc6e6958ef7c42daa57e06cf1d347e8387d766d1172a125175719b5cR1-R10) [[2]](diffhunk://#diff-5679fdf87972acc2c0509534abd3743ce89b98ff956b39e2b67df5e9059237f4R1-R102)
- Updated dependency injection configuration to register the new repositories and unit of work.

**Score Repository Enhancements:**

- Refactored `ScoreRepository` to inherit from `BaseRepository<Score>`, adding robust logging and exception handling to all methods.
- Expanded `IScoreRepository` with new methods for advanced querying, such as retrieving top scores by date range, best score by alias, player statistics, recent scores, and ranking positions. [[1]](diffhunk://#diff-181dee0c4231d0cf9404d74a324691902d6214cf925d7bd5a14d535ed665d3deR4-R20) [[2]](diffhunk://#diff-ae4116d32b938c1853b7077002a82c313eb5cd4bcdd4474f1fb838591721bfaeR5-R236)

**Score Statistics Functionality:**

- Introduced the `ScoreStatistics` DTO for aggregating player score data, and implemented its computation in the repository. [[1]](diffhunk://#diff-e85b4f65fd8342d046d2109f4b0b9f5b4f7a5c9a53e48ae0ffb7a0a3a7e5cff1R1-R11) [[2]](diffhunk://#diff-ae4116d32b938c1853b7077002a82c313eb5cd4bcdd4474f1fb838591721bfaeR5-R236)

**Other Improvements:**

- Improved the API documentation description to reflect the adoption of hexagonal architecture.